### PR TITLE
Feature/#23/accept purchase product

### DIFF
--- a/src/main/java/com/example/cupcycle/controller/PurchaseController.java
+++ b/src/main/java/com/example/cupcycle/controller/PurchaseController.java
@@ -37,4 +37,20 @@ public class PurchaseController {
                     .body(new ApiResponse<>(false,6001, e.getMessage()));
         }
     }
+
+    /*
+     * 상품 구매 수락
+     */
+    @PostMapping("/acceptPurchase")
+    public ResponseEntity<ApiResponse<Void>> acceptPurchase(
+            @RequestParam int purchaseHistoryId) {
+        try {
+            purchaseService.acceptPurchase(purchaseHistoryId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ApiResponse<>(true,200, "구매가 성공적으로 수락되었습니다.", null));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ApiResponse<>(false,6001, e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/com/example/cupcycle/controller/PurchaseController.java
+++ b/src/main/java/com/example/cupcycle/controller/PurchaseController.java
@@ -1,0 +1,40 @@
+package com.example.cupcycle.controller;
+
+import com.example.cupcycle.entity.PurchaseHistory;
+import com.example.cupcycle.service.ApiResponse;
+import com.example.cupcycle.service.PurchaseService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/purchase")
+public class PurchaseController {
+    private final PurchaseService purchaseService;
+
+    @Autowired
+    public PurchaseController(PurchaseService purchaseService) {
+        this.purchaseService = purchaseService;
+    }
+
+    /*
+    * 상품 구매 신청
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<PurchaseHistory>> purchaseProduct(
+            @RequestParam int studentId,
+            @RequestParam int productId) {
+        try {
+            PurchaseHistory purchaseHistory = purchaseService.purchaseProduct(studentId, productId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ApiResponse<>(true,200, "상품이 성공적으로 구매되었습니다.", purchaseHistory));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ApiResponse<>(false,6001, "상품을 구매할 수 없습니다."));
+        }
+    }
+}

--- a/src/main/java/com/example/cupcycle/controller/PurchaseController.java
+++ b/src/main/java/com/example/cupcycle/controller/PurchaseController.java
@@ -30,7 +30,7 @@ public class PurchaseController {
             @RequestParam int productId) {
         try {
             PurchaseHistory purchaseHistory = purchaseService.purchaseProduct(studentId, productId);
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            return ResponseEntity.status(HttpStatus.OK)
                     .body(new ApiResponse<>(true,200, "물품 교환 신청이 완료되었습니다.", purchaseHistory));
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -46,7 +46,7 @@ public class PurchaseController {
             @RequestParam int purchaseHistoryId) {
         try {
             purchaseService.acceptPurchase(purchaseHistoryId);
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            return ResponseEntity.status(HttpStatus.OK)
                     .body(new ApiResponse<>(true,200, "구매가 성공적으로 수락되었습니다.", null));
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)

--- a/src/main/java/com/example/cupcycle/controller/PurchaseController.java
+++ b/src/main/java/com/example/cupcycle/controller/PurchaseController.java
@@ -34,7 +34,7 @@ public class PurchaseController {
                     .body(new ApiResponse<>(true,200, "상품 신청이 완료되었습니다.", purchaseHistory));
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ApiResponse<>(false,6001, "상품 신청이 불가합니다."));
+                    .body(new ApiResponse<>(false,6001, e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/example/cupcycle/controller/PurchaseController.java
+++ b/src/main/java/com/example/cupcycle/controller/PurchaseController.java
@@ -24,7 +24,7 @@ public class PurchaseController {
     /*
     * 상품 구매 신청
      */
-    @PostMapping
+    @PostMapping("/requestPurchase")
     public ResponseEntity<ApiResponse<PurchaseHistory>> purchaseProduct(
             @RequestParam int studentId,
             @RequestParam int productId) {

--- a/src/main/java/com/example/cupcycle/controller/PurchaseController.java
+++ b/src/main/java/com/example/cupcycle/controller/PurchaseController.java
@@ -31,10 +31,10 @@ public class PurchaseController {
         try {
             PurchaseHistory purchaseHistory = purchaseService.purchaseProduct(studentId, productId);
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ApiResponse<>(true,200, "상품이 성공적으로 구매되었습니다.", purchaseHistory));
+                    .body(new ApiResponse<>(true,200, "상품 신청이 완료되었습니다.", purchaseHistory));
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ApiResponse<>(false,6001, "상품을 구매할 수 없습니다."));
+                    .body(new ApiResponse<>(false,6001, "상품 신청이 불가합니다."));
         }
     }
 }

--- a/src/main/java/com/example/cupcycle/controller/PurchaseController.java
+++ b/src/main/java/com/example/cupcycle/controller/PurchaseController.java
@@ -31,7 +31,7 @@ public class PurchaseController {
         try {
             PurchaseHistory purchaseHistory = purchaseService.purchaseProduct(studentId, productId);
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ApiResponse<>(true,200, "상품 신청이 완료되었습니다.", purchaseHistory));
+                    .body(new ApiResponse<>(true,200, "물품 교환 신청이 완료되었습니다.", purchaseHistory));
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(new ApiResponse<>(false,6001, e.getMessage()));

--- a/src/main/java/com/example/cupcycle/entity/Product.java
+++ b/src/main/java/com/example/cupcycle/entity/Product.java
@@ -1,0 +1,25 @@
+package com.example.cupcycle.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int productId; // 상품 ID
+
+    @Column(nullable = false, length = 100)
+    private String name; // 상품 이름
+
+    @Column(nullable = false)
+    private Integer price; // 상품 가격
+}

--- a/src/main/java/com/example/cupcycle/entity/PurchaseHistory.java
+++ b/src/main/java/com/example/cupcycle/entity/PurchaseHistory.java
@@ -29,4 +29,7 @@ public class PurchaseHistory {
 
     @Column(nullable = false)
     private Timestamp purchaseDate; // 구매 날짜
+
+    @Column(nullable = false)
+    private boolean isAccepted; // 구매 수락 여부
 }

--- a/src/main/java/com/example/cupcycle/entity/PurchaseHistory.java
+++ b/src/main/java/com/example/cupcycle/entity/PurchaseHistory.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.security.Timestamp;
+import java.sql.Timestamp;
 
 @Entity
 @Table(name = "purchase_history")

--- a/src/main/java/com/example/cupcycle/entity/PurchaseHistory.java
+++ b/src/main/java/com/example/cupcycle/entity/PurchaseHistory.java
@@ -1,0 +1,32 @@
+package com.example.cupcycle.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.security.Timestamp;
+
+@Entity
+@Table(name = "purchase_history")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PurchaseHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int purchaseId; // 구매 ID
+
+    @ManyToOne
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student; // 구매한 학생
+
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product; // 구매한 상품
+
+    @Column(nullable = false)
+    private Timestamp purchaseDate; // 구매 날짜
+}

--- a/src/main/java/com/example/cupcycle/entity/ReturnStation.java
+++ b/src/main/java/com/example/cupcycle/entity/ReturnStation.java
@@ -41,6 +41,6 @@ public class ReturnStation {
     }
 
     public void increaseCurrentCup() {
-        this.current_cup++;
+        this.currentCup++;
     }
 }

--- a/src/main/java/com/example/cupcycle/repository/ProductRepository.java
+++ b/src/main/java/com/example/cupcycle/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.example.cupcycle.repository;
+
+import com.example.cupcycle.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Integer> {
+}

--- a/src/main/java/com/example/cupcycle/repository/PurchaseHistoryRepository.java
+++ b/src/main/java/com/example/cupcycle/repository/PurchaseHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.cupcycle.repository;
+
+import com.example.cupcycle.entity.PurchaseHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PurchaseHistoryRepository extends JpaRepository<PurchaseHistory, Integer> {
+}

--- a/src/main/java/com/example/cupcycle/service/PurchaseService.java
+++ b/src/main/java/com/example/cupcycle/service/PurchaseService.java
@@ -6,6 +6,7 @@ import com.example.cupcycle.entity.Student;
 import com.example.cupcycle.repository.ProductRepository;
 import com.example.cupcycle.repository.PurchaseHistoryRepository;
 import com.example.cupcycle.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,19 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.sql.Timestamp;
 
 @Service
+@RequiredArgsConstructor
 public class PurchaseService {
     private final StudentRepository studentRepository;
     private final ProductRepository productRepository;
     private final PurchaseHistoryRepository purchaseHistoryRepository;
-
-    @Autowired
-    public PurchaseService(StudentRepository studentRepository,
-                           ProductRepository productRepository,
-                           PurchaseHistoryRepository purchaseHistoryRepository) {
-        this.studentRepository = studentRepository;
-        this.productRepository = productRepository;
-        this.purchaseHistoryRepository = purchaseHistoryRepository;
-    }
 
     @Transactional
     public PurchaseHistory purchaseProduct(int studentId, int productId) {
@@ -40,6 +33,7 @@ public class PurchaseService {
             throw new RuntimeException("리워드 포인트가 부족합니다.");
         }
 
+
         // 구매 이력 생성
         PurchaseHistory purchaseHistory = PurchaseHistory.builder()
                 .student(student)
@@ -48,5 +42,37 @@ public class PurchaseService {
                 .build();
 
         return purchaseHistoryRepository.save(purchaseHistory);
+    }
+
+
+    /*
+    * 상품 구매 수락
+    */
+    @Transactional
+    public void acceptPurchase(int purchaseId) {
+        PurchaseHistory purchaseHistory = purchaseHistoryRepository.findById(purchaseId)
+                .orElseThrow(() -> new RuntimeException("구매 이력을 찾을 수 없습니다."));
+
+        // 구매 수락 처리
+        if (purchaseHistory.isAccepted()) {
+            throw new RuntimeException("이미 수락된 구매입니다.");
+        }
+
+        // 학생 정보 가져오기
+        Student student = purchaseHistory.getStudent();
+        Product product = purchaseHistory.getProduct();
+        int cost = product.getPrice();
+
+        // 리워드 차감
+        if (student.getReward() < cost) {
+            throw new RuntimeException("리워드 포인트가 부족합니다.");
+        }
+
+        // 학생 정보 업데이트
+        student.setReward(student.getReward() - cost);
+        studentRepository.save(student);
+
+        purchaseHistory.setAccepted(true);
+        purchaseHistoryRepository.save(purchaseHistory);
     }
 }

--- a/src/main/java/com/example/cupcycle/service/PurchaseService.java
+++ b/src/main/java/com/example/cupcycle/service/PurchaseService.java
@@ -1,0 +1,56 @@
+package com.example.cupcycle.service;
+
+import com.example.cupcycle.entity.Product;
+import com.example.cupcycle.entity.PurchaseHistory;
+import com.example.cupcycle.entity.Student;
+import com.example.cupcycle.repository.ProductRepository;
+import com.example.cupcycle.repository.PurchaseHistoryRepository;
+import com.example.cupcycle.repository.StudentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+
+@Service
+public class PurchaseService {
+    private final StudentRepository studentRepository;
+    private final ProductRepository productRepository;
+    private final PurchaseHistoryRepository purchaseHistoryRepository;
+
+    @Autowired
+    public PurchaseService(StudentRepository studentRepository,
+                           ProductRepository productRepository,
+                           PurchaseHistoryRepository purchaseHistoryRepository) {
+        this.studentRepository = studentRepository;
+        this.productRepository = productRepository;
+        this.purchaseHistoryRepository = purchaseHistoryRepository;
+    }
+
+    @Transactional
+    public PurchaseHistory purchaseProduct(int studentId, int productId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new RuntimeException("학생을 찾을 수 없습니다."));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다."));
+
+        int productPrice = product.getPrice();
+
+        if (student.getReward() < productPrice) {
+            throw new RuntimeException("리워드 포인트가 부족합니다.");
+        }
+
+        // 리워드 차감
+        student.setReward(student.getReward() - productPrice);
+        studentRepository.save(student);
+
+        // 구매 이력 생성
+        PurchaseHistory purchaseHistory = PurchaseHistory.builder()
+                .student(student)
+                .product(product)
+                .purchaseDate(new Timestamp(System.currentTimeMillis()))
+                .build();
+
+        return purchaseHistoryRepository.save(purchaseHistory);
+    }
+}

--- a/src/main/java/com/example/cupcycle/service/PurchaseService.java
+++ b/src/main/java/com/example/cupcycle/service/PurchaseService.java
@@ -40,10 +40,6 @@ public class PurchaseService {
             throw new RuntimeException("리워드 포인트가 부족합니다.");
         }
 
-        // 리워드 차감
-        student.setReward(student.getReward() - productPrice);
-        studentRepository.save(student);
-
         // 구매 이력 생성
         PurchaseHistory purchaseHistory = PurchaseHistory.builder()
                 .student(student)


### PR DESCRIPTION
## 📄 작업 내용 요약
### 상품 구매 수락

- 구매 이력 Id를 통해 정보를 가져옵니다.
- 구매 수락 과정
  - 구매 수락 처리 (이미 수락된 구매일 경우, 예외 발생)
  - 학생 정보와 상품 정보 가져옴
  **_- 리워드 차감 시 리워드가 부족하면 예외 발생_**
  - 학생 정보 업데이트
  - 구매 수락 여부 업데이트

## 📎 Issue 번호
#23 

## 참고사항
### [ 리워드 차감 시 리워드가 부족하면 예외 발생 ]
학생이 여러 물품을 신청한 경우, 구매 신청 목록에서 각 신청이 수락되면서 리워드가 차감됩니다. 
하지만, 신청 과정에서는 리워드가 차감되지 않습니다. 즉 여러 개를 신청하는 경우에는 리워드가 부족한지 정확히 알 수 없습니다.
따라서, 현재 코드로는 신청 과정에서 이러한 예외를 잡지 못해서 이 문제는 추후 생각해 보고 리팩토링 과정에서 수정하면 될 것 같습니다.

일단은 구매 수락 과정에서도 리워드 차감 시 리워드가 부족한지 예외 처리 코드를 넣어놓았습니다.