### PR TITLE
상품 신청 목록 조회 API response 간소화

### DIFF
--- a/src/main/java/com/example/cupcycle/controller/PurchaseController.java
+++ b/src/main/java/com/example/cupcycle/controller/PurchaseController.java
@@ -1,5 +1,6 @@
 package com.example.cupcycle.controller;
 
+import com.example.cupcycle.dto.PurchaseHistoryDto;
 import com.example.cupcycle.entity.PurchaseHistory;
 import com.example.cupcycle.service.ApiResponse;
 import com.example.cupcycle.service.PurchaseService;
@@ -53,8 +54,8 @@ public class PurchaseController {
      * 상품 구매 신청 목록 조회
      */
     @GetMapping("/getPurchaseHistory")
-    public ResponseEntity<ApiResponse<List<PurchaseHistory>>> getPurchaseHistory() {
-        List<PurchaseHistory> purchaseHistoryList = purchaseService.getPurchaseHistory();
+    public ResponseEntity<ApiResponse<List<PurchaseHistoryDto>>> getPurchaseHistory() {
+        List<PurchaseHistoryDto> purchaseHistoryList = purchaseService.getPurchaseHistory();
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new ApiResponse<>(true,200, "구매 신청 목록 조회에 성공하였습니다.", purchaseHistoryList));
     }

--- a/src/main/java/com/example/cupcycle/dto/PurchaseHistoryDto.java
+++ b/src/main/java/com/example/cupcycle/dto/PurchaseHistoryDto.java
@@ -1,0 +1,12 @@
+package com.example.cupcycle.dto;
+
+import lombok.Data;
+
+@Data
+public class PurchaseHistoryDto {
+    private int purchaseId;
+    private int studentId;
+    private String studentName;
+    private int productId;
+    private String productName;
+}

--- a/src/main/java/com/example/cupcycle/service/PurchaseService.java
+++ b/src/main/java/com/example/cupcycle/service/PurchaseService.java
@@ -1,5 +1,6 @@
 package com.example.cupcycle.service;
 
+import com.example.cupcycle.dto.PurchaseHistoryDto;
 import com.example.cupcycle.entity.Product;
 import com.example.cupcycle.entity.PurchaseHistory;
 import com.example.cupcycle.entity.Student;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -72,7 +74,20 @@ public class PurchaseService {
     /*
      * 상품 신청 목록 조회
      */
-    public List<PurchaseHistory> getPurchaseHistory() {
-        return purchaseHistoryRepository.findAll();
+//    public List<PurchaseHistory> getPurchaseHistory() {
+//        return purchaseHistoryRepository.findAll();
+//    }
+    public List<PurchaseHistoryDto> getPurchaseHistory() {
+        List<PurchaseHistory> purchaseHistoryList = purchaseHistoryRepository.findAll();
+        return purchaseHistoryList.stream().map(purchaseHistory -> {
+            PurchaseHistoryDto dto = new PurchaseHistoryDto();
+            dto.setPurchaseId(purchaseHistory.getPurchaseId());
+            dto.setStudentId(purchaseHistory.getStudent().getStudentId());
+            dto.setStudentName(purchaseHistory.getStudent().getName());
+            dto.setProductId(purchaseHistory.getProduct().getProductId());
+            dto.setProductName(purchaseHistory.getProduct().getName());
+            return dto;
+        }).collect(Collectors.toList());
     }
+
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
**상품 신청 목록 조회 API response 간소화**
프론트 요청에 따라
( purchaseId, studentId, studentName, productId, productName ) 만 반환하도록 변경

- 변경된 response
```
{
    "code": 200,
    "message": "구매 신청 목록 조회에 성공하였습니다.",
    "data": [
        {
            "purchaseId": 10,
            "studentId": 2,
            "studentName": "최인준",
            "productId": 1,
            "productName": "인덕이 그립톡"
        },
        {
            "purchaseId": 11,
            "studentId": 1,
            "studentName": "김민지",
            "productId": 1,
            "productName": "인덕이 그립톡"
        }
    ],
    "success": true
}
```

## 📎 Issue 번호
#41 
